### PR TITLE
adapt persistence layer for Alexa-Hosted

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -1,4 +1,4 @@
-const Alexa = require('ask-sdk');
+const Alexa = require('ask-sdk-core');
 const utils = require("./utils");
 
 const LaunchRequestHandler = {
@@ -409,7 +409,7 @@ const ErrorHandler = {
   }
 };
 
-const skillBuilder = Alexa.SkillBuilders.standard();
+const skillBuilder = Alexa.SkillBuilders.custom();
 
 exports.handler = skillBuilder
   .addRequestHandlers(
@@ -431,7 +431,7 @@ exports.handler = skillBuilder
     utils.LoadAttributesRequestInterceptor,
     utils.LocalisationRequestInterceptor)
   .addResponseInterceptors(utils.SaveAttributesResponseInterceptor)
-  .withTableName("premium-hello-world") // requires that you allow DynamoDB access in your Lambda role!
-  .withAutoCreateTable(true)
+  .withPersistenceAdapter(utils.getPersistenceAdapter())
+  .withApiClient(new Alexa.DefaultApiClient())
   .withCustomUserAgent('sample/premium-hello-world/v1.2')
   .lambda();

--- a/lambda/custom/package.json
+++ b/lambda/custom/package.json
@@ -9,7 +9,10 @@
   "author": "Amazon Alexa",
   "license": "ASL",
   "dependencies": {
-    "ask-sdk": "^2.7.0",
+    "ask-sdk-core": "^2.7.0",
+    "ask-sdk-model": "^1.24.0",
+    "ask-sdk-s3-persistence-adapter": "^2.7.0",
+    "ask-sdk-dynamodb-persistence-adapter": "^2.7.0",
     "i18next": "^15.0.5",
     "aws-sdk": "^2.326.0"
   }

--- a/lambda/custom/utils.js
+++ b/lambda/custom/utils.js
@@ -1,4 +1,4 @@
-const Alexa = require('ask-sdk');
+const Alexa = require('ask-sdk-core');
 const i18n = require('i18next');
 const languageStrings = require('./localisation');
 const GOODBYES_PER_ENTITLEMENT = 3;
@@ -328,6 +328,26 @@ function getBuyResponseText(handlerInput, productReferenceName, productName) {
   }
 }
 
+function getPersistenceAdapter(tableName) {
+  // This function is an indirect way to detect if this is part of an Alexa-Hosted skill
+  function isAlexaHosted() {
+      return process.env.S3_PERSISTENCE_BUCKET;
+  }
+  if (isAlexaHosted()) {
+      const {S3PersistenceAdapter} = require('ask-sdk-s3-persistence-adapter');
+      return new S3PersistenceAdapter({ 
+          bucketName: process.env.S3_PERSISTENCE_BUCKET
+      });
+  } else {
+      // IMPORTANT: don't forget to give DynamoDB access to the role you're using to run this lambda (via IAM policy)
+      const {DynamoDbPersistenceAdapter} = require('ask-sdk-dynamodb-persistence-adapter');
+      return new DynamoDbPersistenceAdapter({ 
+          tableName: tableName || 'premium-hello-world',
+          createTable: true
+      });
+  }
+}
+
 // *****************************************
 // *********** Interceptors ************
 // *****************************************
@@ -382,6 +402,7 @@ const LocalisationRequestInterceptor = {
 };
 
 module.exports = {
+    getPersistenceAdapter,
     isPurchasable,
     makeUpsell,
     getAllEntitledProducts,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add the ability to use S3 as persistence for Alexa-Hosted Skill and fallback to DynamoDB otherwise

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
