### PR TITLE
remove auto-delegation usage for product description

### DIFF
--- a/models/fr-FR.json
+++ b/models/fr-FR.json
@@ -67,14 +67,7 @@
                     "slots": [
                         {
                             "name": "product",
-                            "type": "productType",
-                            "samples": [
-                                "plus d'information sur {product}",
-                                "{product}",
-                                "le {product}",
-                                "le produit {product}",
-                                "description {product}"
-                            ]
+                            "type": "productType"
                         }
                     ],
                     "samples": [
@@ -208,7 +201,7 @@
             "intents": [
                 {
                     "name": "DescribeProductIntent",
-                    "delegationStrategy": "ALWAYS",
+                    "delegationStrategy": "SKILL_RESPONSE",
                     "confirmationRequired": false,
                     "prompts": {},
                     "slots": [
@@ -216,10 +209,8 @@
                             "name": "product",
                             "type": "productType",
                             "confirmationRequired": false,
-                            "elicitationRequired": true,
-                            "prompts": {
-                                "elicitation": "Elicit.Slot.593674792803.723737651317"
-                            }
+                            "elicitationRequired": false,
+                            "prompts": {}
                         }
                     ]
                 },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Auto-Delegation not compatible with ISP Connections.SendRequest directive.
fr-FR model : Remove Auto-Delegation usage on DescribeProductIntent intent

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
